### PR TITLE
Add a snap package (https://snapcraft.io)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,21 @@
     "dist-x": "build -ml",
     "release": "build"
   },
+  "build": {
+    "appId": "de.hendrikwallbaum.blankUpElectron",
+    "mac": {
+      "category": "public.app-category.productivity"
+    },
+    "linux": {
+      "target": "snap"
+    },
+    "snap": {
+      "plugs": [
+        "default",
+        "desktop"
+      ]
+    }
+  },
   "private": true,
   "repository": {
     "type": "git",
@@ -31,7 +46,7 @@
   "homepage": "https://github.com/HoverBaum/BlankUp-Electron",
   "devDependencies": {
     "concurrently": "^2.2.0",
-    "electron-builder": "^5.16.0",
+    "electron-builder": "^19.45.5",
     "electron-prebuilt": "^1.2.0",
     "electron-reload": "^1.0.0",
     "stylus": "^0.54.5"
@@ -39,9 +54,5 @@
   "dependencies": {
     "BlankUp": "^0.3.2",
     "choo": "^3.2.0"
-  },
-  "build": {
-    "appId": "de.hendrikwallbaum.blankUpElectron",
-    "app-category-type": "public.app-category.productivity"
   }
 }


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 16.04, but it should work just as well on Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run dist -- -l` it will create `dist/blankup_1.1.0_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous blankup_1.1.0_amd64.snap`

Run with `blankup` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "blankup" name](https://dashboard.snapcraft.io/register-snap/?name=blankup).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push BlankUp out with:
`snapcraft push blankup_1.1.0_amd64.snap --release stable`

(You can also push to the Snap Store [programmatically from Travis](https://docs.snapcraft.io/build-snaps/ci-integration#using-travis).)